### PR TITLE
Save mat files in HDF5 format

### DIFF
--- a/+BE_Controller/Data.m
+++ b/+BE_Controller/Data.m
@@ -706,9 +706,9 @@ function saveData(model, filePath)
             'parameters', parameters, ...
             'results', model.results, ...
             'displaySettings', model.displaySettings ...
-        ); %#ok<NASGU>
+        );
 
-        save(filePath, 'results');
+        save(filePath, 'results', '-v7.3');
     end
     model.log.log(['I/File: Saved file "' filePath '"']);
 end

--- a/+BE_Controller/Evaluation.m
+++ b/+BE_Controller/Evaluation.m
@@ -460,8 +460,6 @@ function evaluate(view, model)
             end
         end
     end
-    
-%     save('Brillouin_spectra.mat', 'spectra');
 
     %% issue warnings when Rayleigh or Brillouin peaks could not be fitted
     if warningRayleigh


### PR DESCRIPTION
This allows opening the resulting mat files with any HDF5 compatible program.

Closes #19.